### PR TITLE
cargo: bump cudarc to 0.19.8 (fixes #56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading 0.9.0",
 ]


### PR DESCRIPTION
Changes verified using:

```
CPU: 16-core AMD Ryzen Threadripper 1950X (-MT MCP-)
Distro: CachyOS 
Kernel: 7.1.2-1-cachyos-bore-lto x86_64
Desktop: niri
CUBLAS Version 13.6.0.2
cargo 1.96.0-nightly (cbb9bb8bd 2026-03-13)
rustc 1.96.0-nightly (1e2183119 2026-03-15)
```